### PR TITLE
Zapisz plik po pobraniu go

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -118,6 +118,15 @@ int downloadbashdata() {
     curl_easy_cleanup(curl);
   }
   else return 1;
+  ofstream plik;
+  plik.open(bashdata_location.c_str());
+  if(plik.is_open()) {
+    plik.write(bashdata, l);
+    plik.close();
+  }
+  else {
+    cout<<"Nie udało się zapisać nowych danych do "<<bashdata_location<<endl;
+  }
   return 0;
 }
 //pokazuje ostrzeżenie jak plik nie byl modyfikowany przez więcej niż 14 dni


### PR DESCRIPTION
Jak się okazało, zapomniałem o dość istotnej rzeczy. Otóż gdy plik był starszy niż 14 dni, nowa wersja była pobierana z internetu. Problemem było to, że ta nowa wersja nie była zapisywana, i przy kolejnym uruchomieniu znowu się pobierała z internetu. Żeby nie wkurzać administratora bash.org.pl, wprowadzam tą oto poprawkę.